### PR TITLE
Implement in Fastly VCL

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ riffRaffBuildIdentifier :=  Option(System.getenv("CIRCLE_BUILD_NUM")).getOrElse(
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestBranch := Option(System.getenv("CIRCLE_BRANCH")).getOrElse("dev")
+riffRaffArtifactResources += baseDirectory.value / "vcl" / "main.vcl" -> "ip-checker/main.vcl"
 
 javaOptions in Universal ++= Seq(
   "-Dpidfile.path=/dev/null",

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -2,8 +2,18 @@ stacks:
  - frontend
 regions:
  - eu-west-1
+templates:
+  ip-checker-vcl:
+    type: fastly
+    contentDirectory: ip-checker
 deployments:
   ipv6-checker:
     type: autoscaling
     parameters:
       bucket: aws-frontend-artifacts
+  ip-checker-v4:
+    template: ip-checker-vcl
+  ip-checker-dual:
+    template: ip-checker-vcl
+  ip-checker-v6:
+    template: ip-checker-vcl

--- a/vcl/main.vcl
+++ b/vcl/main.vcl
@@ -1,14 +1,6 @@
-acl ipv4 {
-  "0.0.0.0"/0;
-}
-
 sub vcl_recv {
 #FASTLY recv
-    if (client.ip ~ ipv4) {
-        error 854 "";
-    } else {
-        error 856 "";
-    }
+    error 850 "";
 }
 
 sub vcl_error {
@@ -16,14 +8,15 @@ sub vcl_error {
     ####################
     # Return ip mode
     ####################
-    if (obj.status == 854 || obj.status == 856) {
+    if (obj.status == 850) {
         set obj.status = 200;
         set obj.http.Content-Type = "text/plain;";
         set obj.http.X-Client-Ip = client.ip;
-        if (obj.status == 854) {
-            synthetic {"ipv4"};
-        } else {
+        # Setting a header to the IP converts it to a string which can then be regex matched
+        if (obj.http.X-Client-Ip ~ ":") {
             synthetic {"ipv6"};
+        } else {
+            synthetic {"ipv4"};
         }
         return(deliver);
     }

--- a/vcl/main.vcl
+++ b/vcl/main.vcl
@@ -1,0 +1,30 @@
+acl ipv4 {
+  "0.0.0.0"/0;
+}
+
+sub vcl_recv {
+#FASTLY recv
+    if (client.ip ~ ipv4) {
+        error 854 "";
+    } else {
+        error 856 "";
+    }
+}
+
+sub vcl_error {
+#FASTLY error
+    ####################
+    # Return ip mode
+    ####################
+    if (obj.status == 854 || obj.status == 856) {
+        set obj.status = 200;
+        set obj.http.Content-Type = "text/plain;";
+        set obj.http.X-Client-Ip = client.ip;
+        if (obj.status == 854) {
+            synthetic {"ipv4"};
+        } else {
+            synthetic {"ipv6"};
+        }
+        return(deliver);
+    }
+}


### PR DESCRIPTION
Implement the IPv6 checker in VCL so it can be hosted in Fastly.

This currently deploys the VCL to three different services, although I think it might be possible to reduce this to one service.