### PR TITLE
Stop using req.is_ipv6 as it seems to be broken

### DIFF
--- a/vcl/main.vcl
+++ b/vcl/main.vcl
@@ -1,10 +1,6 @@
 sub vcl_recv {
 #FASTLY recv
-    if (req.is_ipv6) {
-        error 850 "ipv6";
-    } else {
-        error 850 "ipv4";
-    }
+    error 850 "";
 }
 
 sub vcl_error {
@@ -17,7 +13,12 @@ sub vcl_error {
         set obj.http.Content-Type = "text/plain;";
         set obj.http.X-Client-Ip = client.ip;
         set obj.http.Access-Control-Allow-Origin = "*";
-        synthetic obj.response;
+        # Setting a header to the IP converts it to a string which can then be regex matched
+        if (obj.http.X-Client-Ip ~ ":") {
+            synthetic {"ipv6"};
+        } else {
+            synthetic {"ipv4"};
+        }
         return(deliver);
     }
 }


### PR DESCRIPTION
Getting lots of reports of IPv4 connections on the IPv6 only domain. Think that req.is_ipv6 is false in some IPv6 scenarios. Going to test by reverting the previous approach.